### PR TITLE
[FIX] Resolve reported Actions errors

### DIFF
--- a/.github/workflows/snyk_container.yml
+++ b/.github/workflows/snyk_container.yml
@@ -8,7 +8,6 @@ on:
       - completed
   schedule:
     - cron: "39 4 * * 0"
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -22,20 +21,30 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+      - uses: actions/checkout@v4
       #- name: Build a Docker image
       #  run: docker build -t black-mirror .
       - name: Run Snyk to check Docker image for vulnerabilities
         # Snyk can be used to break the build when it detects vulnerabilities.
         # In this case we want to upload the issues to GitHub Code Scanning
         continue-on-error: true
-        uses: snyk/actions/docker@cdb760004ba9ea4d525f2e043745dfe85bb9077e
+        uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ghcr.io/t145/black-mirror:latest
-          args: --file=docker/Dockerfile
+          args: --file=docker/Dockerfile.chainguard
+      - name: "Filter SARIF for GitHub"
+        shell: bash
+        # Snyk produces multiple runs when --file is used.
+        # GitHub now requires unique categories for each run in a single upload.
+        # We'll keep only the first run (the image scan) to satisfy GitHub's policy.
+        run: |
+          if [ -f snyk.sarif ]; then
+            jq '.runs = [.runs[0]]' snyk.sarif > snyk.sarif.tmp && mv snyk.sarif.tmp snyk.sarif
+          fi
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@c43362b91a940600cde2ebae39ec7a35ad66bdc0
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
+          category: snyk-container

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -130,6 +130,16 @@ RUN apk update; \
     apk add --no-cache bash=5.3-r3 ca-certificates=20251003-r0 curl=8.12.1-r0 coreutils=9.6-r0 findutils=4.10.0-r0 gnutar=1.35-r0 xz=5.6.4-r0 unzip=6.0-r18 zip=3.0-r12 gzip=1.13-r0 \
         shadow=4.17.3-r0 util-linux=2.40.4-r0 tzdata=2025a-r0 gettext=0.22.5-r0 openssl=3.6.0-r6 python3=3.13.11-r2 py3-pip=25.0.1-r0 bc=1.07.1-r5 gawk=5.3.1-r0 git=2.47.2-r0 lynx=2.9.2-r0 nodejs=23.8.0-r0 npm=10.9.2-r0 whois=5.5.23-r0 \
         c-ares=1.34.4-r0 libssh2=1.11.1-r0 sqlite-libs=3.48.0-r0 libxml2=2.13.5-r0 glibc-locale-en=2.42-r4 libidn2=2.3.7-r0 libunistring=1.2-r0 patch=2.7.6-r7; \
+    # Enable the OpenSSL legacy provider, which is required for aria2's checksumming features.
+    # https://github.com/aria2/aria2/issues/2143
+    sed -i 's/^#legacy = legacy_sect/legacy = legacy_sect/' /etc/ssl/openssl.cnf || true; \
+    sed -i 's/^#\[legacy_sect\]/\[legacy_sect\]/' /etc/ssl/openssl.cnf || true; \
+    if ! grep -q "^\[legacy_sect\]" /etc/ssl/openssl.cnf; then \
+        printf "\n[legacy_sect]\nactivate = 1\n" >> /etc/ssl/openssl.cnf; \
+    fi; \
+    if ! grep -q "^legacy = legacy_sect" /etc/ssl/openssl.cnf; then \
+        sed -i '/^\[provider_sect\]/a legacy = legacy_sect' /etc/ssl/openssl.cnf || true; \
+    fi; \
     rm -rf /var/cache/apk/*
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/scripts/v2/build_lists.bash
+++ b/scripts/v2/build_lists.bash
@@ -79,6 +79,7 @@ main() {
 
 	for method in "${METHODS[@]}"; do
 		cache="${DOWNLOADS}/${method}"
+		mkdir -p "$cache"
 
 		echo "[INFO] Processing method: ${method}"
 


### PR DESCRIPTION
Should fix Snyk image scan uploads to GitHub Code Scanning, and this error reported by the scripts:
```
[INFO] Processing method: BLOCK
[INFO] Downloading BLOCK lists...
Exception caught
Exception: [Platform.cc:125] errorCode=1 OSSL_PROVIDER_load 'legacy' failed.

Error: Broken pipe (os error 32)
sponge: cannot open /tmp/tmp.mlBKGR9Ed6/BLOCK/circl: No such file or directory
END failed--call queue aborted, <> line 567.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0Warning: Failed to open the file /tmp/tmp.mlBKGR9Ed6/BLOCK/abuse_ipdb: No such 
Warning: file or directory

  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
curl: (23) client returned ERROR on write of 1360 bytes
Error:  ENOENT: no such file or directory, open '/tmp/tmp.mlBKGR9Ed6/BLOCK/bestpika_yui'
  at async open (node:internal/fs/promises:641:25)
  at async Object.writeFile (node:internal/fs/promises:1249:14)
  at async main (/usr/local/lib/node_modules/@adguard/hostlist-compiler/src/cli.js:123:9)
Error:  ENOENT: no such file or directory, open '/tmp/tmp.mlBKGR9Ed6/BLOCK/cjxlist'
  at async open (node:internal/fs/promises:641:25)
  at async Object.writeFile (node:internal/fs/promises:1249:14)
  at async main (/usr/local/lib/node_modules/@adguard/hostlist-compiler/src/cli.js:123:9)
Error:  ENOENT: no such file or directory, open '/tmp/tmp.mlBKGR9Ed6/BLOCK/uassets_badware'
  at async open (node:internal/fs/promises:641:25)
  at async Object.writeFile (node:internal/fs/promises:1249:14)
  at async main (/usr/local/lib/node_modules/@adguard/hostlist-compiler/src/cli.js:123:9)
Error:  ENOENT: no such file or directory, open '/tmp/tmp.mlBKGR9Ed6/BLOCK/uassets_filters_2020'
  at async open (node:internal/fs/promises:641:25)
  at async Object.writeFile (node:internal/fs/promises:1249:14)
  at async main (/usr/local/lib/node_modules/@adguard/hostlist-compiler/src/cli.js:123:9)
Error:  ENOENT: no such file or directory, open '/tmp/tmp.mlBKGR9Ed6/BLOCK/uassets_filters_2021'
  at async open (node:internal/fs/promises:641:25)
  at async Object.writeFile (node:internal/fs/promises:1249:14)
  at async main (/usr/local/lib/node_modules/@adguard/hostlist-compiler/src/cli.js:123:9)
Error:  ENOENT: no such file or directory, open '/tmp/tmp.mlBKGR9Ed6/BLOCK/uassets_filters_2022'
  at async open (node:internal/fs/promises:641:25)
  at async Object.writeFile (node:internal/fs/promises:1249:14)
  at async main (/usr/local/lib/node_modules/@adguard/hostlist-compiler/src/cli.js:123:9)
Error:  ENOENT: no such file or directory, open '/tmp/tmp.mlBKGR9Ed6/BLOCK/uassets_filters_2023'
  at async open (node:internal/fs/promises:641:25)
  at async Object.writeFile (node:internal/fs/promises:1249:14)
  at async main (/usr/local/lib/node_modules/@adguard/hostlist-compiler/src/cli.js:123:9)
Error:  ENOENT: no such file or directory, open '/tmp/tmp.mlBKGR9Ed6/BLOCK/uassets_filters_2024'
  at async open (node:internal/fs/promises:641:25)
  at async Object.writeFile (node:internal/fs/promises:1249:14)
  at async main (/usr/local/lib/node_modules/@adguard/hostlist-compiler/src/cli.js:123:9)
Error:  ENOENT: no such file or directory, open '/tmp/tmp.mlBKGR9Ed6/BLOCK/uassets_filters_base'
  at async open (node:internal/fs/promises:641:25)
  at async Object.writeFile (node:internal/fs/promises:1249:14)
  at async main (/usr/local/lib/node_modules/@adguard/hostlist-compiler/src/cli.js:123:9)
Error:  ENOENT: no such file or directory, open '/tmp/tmp.mlBKGR9Ed6/BLOCK/uassets_privacy'
  at async open (node:internal/fs/promises:641:25)
  at async Object.writeFile (node:internal/fs/promises:1249:14)
  at async main (/usr/local/lib/node_modules/@adguard/hostlist-compiler/src/cli.js:123:9)
sponge: cannot open /tmp/tmp.mlBKGR9Ed6/BLOCK/phishtank: No such file or directory
END failed--call queue aborted, <> line 59.

```
The "Publish Lists" workflow not failing masked the error reports for a while.